### PR TITLE
Align property currency toggle with price input

### DIFF
--- a/assets/css/compraroarrendar.css
+++ b/assets/css/compraroarrendar.css
@@ -135,6 +135,100 @@ svg {
     gap: 0.5rem;
 }
 
+.home-price-group {
+    flex-direction: row;
+    align-items: flex-end;
+    gap: 1rem;
+}
+
+.home-price-field {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.currency-toggle-column {
+    align-self: flex-end;
+    display: inline-flex;
+    gap: 0.75rem;
+    padding: 0.25rem 0.75rem;
+    white-space: nowrap;
+}
+
+.currency-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.25rem 0.5rem;
+    background: rgba(66, 153, 225, 0.08);
+    border-radius: 999px;
+}
+
+.currency-toggle-label {
+    font-weight: 600;
+    color: var(--color-text-secondary);
+    font-size: 0.9rem;
+}
+
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 48px;
+    height: 24px;
+}
+
+.switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.switch .slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(226, 232, 240, 0.9);
+    transition: 0.3s;
+    border-radius: 34px;
+}
+
+.switch .slider:before {
+    position: absolute;
+    content: "";
+    height: 20px;
+    width: 20px;
+    left: 2px;
+    bottom: 2px;
+    background-color: #ffffff;
+    border-radius: 50%;
+    transition: 0.3s;
+    box-shadow: 0 2px 6px rgba(15, 23, 42, 0.15);
+}
+
+.switch input:checked + .slider {
+    background: linear-gradient(135deg, #4299e1, #63b3ed);
+}
+
+.switch input:checked + .slider:before {
+    transform: translateX(24px);
+}
+
+@media (max-width: 768px) {
+    .home-price-group {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .currency-toggle-column {
+        align-self: stretch;
+        justify-content: center;
+    }
+}
+
 label {
     font-size: 0.95rem;
     color: var(--color-text-secondary);
@@ -351,6 +445,10 @@ input:focus {
 
 .callout .icon {
     font-size: 1.5rem;
+}
+
+.hidden {
+    display: none !important;
 }
 
 .footer-note {

--- a/assets/js/compraroarrendar.js
+++ b/assets/js/compraroarrendar.js
@@ -9,7 +9,8 @@
         monthlyRent: document.getElementById('monthlyRent'),
         initialInvestment: document.getElementById('initialInvestment'),
         monthlyInvestment: document.getElementById('monthlyInvestment'),
-        annualReturn: document.getElementById('annualReturn')
+        annualReturn: document.getElementById('annualReturn'),
+        ufValue: document.getElementById('ufValue')
     };
 
     const outputs = {
@@ -37,7 +38,29 @@
 
     const recommendation = document.getElementById('recommendation');
 
+    const controls = {
+        dividendCurrencyToggle: document.getElementById('dividendCurrencyToggle'),
+        ufInputGroup: document.querySelector('[data-uf-input-group]'),
+        monthlyPaymentPrefix: document.getElementById('monthlyPaymentPrefix'),
+        monthlyPaymentExplanation: document.getElementById('monthlyPaymentExplanation'),
+        monthlyPaymentRentHint: document.getElementById('monthlyPaymentRentHint'),
+        totalCostLabel: document.getElementById('totalCostLabel'),
+        totalCostHelper: document.getElementById('totalCostHelper'),
+        homePriceLabel: document.querySelector('[data-home-price-label]')
+    };
+
     const currencyFormatter = new Intl.NumberFormat('es-CL');
+    const ufFormatter = new Intl.NumberFormat('es-CL', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    const UF_ANNUAL_GROWTH_RATE = 0.035;
+    const HOME_PRICE_PLACEHOLDERS = {
+        clp: 'Ej: 100.000.000',
+        uf: 'Ej: 3.500'
+    };
+    let lastMonthlyPaymentReferenceClp = 0;
+
+    function isUfSelected() {
+        return Boolean(controls.dividendCurrencyToggle && controls.dividendCurrencyToggle.checked);
+    }
 
     function formatCurrencyInput(input) {
         const raw = input.value.replace(/\D/g, '');
@@ -49,11 +72,63 @@
         return parseInt(String(value).replace(/\D/g, ''), 10) || 0;
     }
 
-    function updateMonthlyInvestment(monthlyPayment) {
+    function parseUfInput(value) {
+        if (!value) return 0;
+        const normalized = String(value)
+            .replace(/\./g, '')
+            .replace(/,/g, '.')
+            .replace(/[^0-9.]/g, '');
+        return parseFloat(normalized) || 0;
+    }
+
+    function formatHomePriceInput() {
+        if (isUfSelected()) {
+            inputs.homePrice.value = inputs.homePrice.value.replace(/[^0-9.,]/g, '');
+        } else {
+            formatCurrencyInput(inputs.homePrice);
+        }
+    }
+
+    function getHomePriceClp() {
+        if (!inputs.homePrice) {
+            return 0;
+        }
+
+        if (!isUfSelected()) {
+            return unformatNumber(inputs.homePrice.value);
+        }
+
+        const ufValue = parseFloat(inputs.ufValue && inputs.ufValue.value);
+        if (!ufValue || Number.isNaN(ufValue) || ufValue <= 0) {
+            return 0;
+        }
+
+        const homePriceUf = parseUfInput(inputs.homePrice.value);
+        if (!homePriceUf) {
+            return 0;
+        }
+
+        return Math.round(homePriceUf * ufValue);
+    }
+
+    function updateHomePriceLabel(usingUf) {
+        if (!controls.homePriceLabel || !inputs.homePrice) {
+            return;
+        }
+
+        controls.homePriceLabel.textContent = usingUf
+            ? 'Valor de la Propiedad (UF)'
+            : 'Valor de la Propiedad (CLP)';
+        inputs.homePrice.placeholder = usingUf
+            ? HOME_PRICE_PLACEHOLDERS.uf
+            : HOME_PRICE_PLACEHOLDERS.clp;
+    }
+
+    function updateMonthlyInvestment(monthlyPaymentClp) {
         const monthlyRentValue = unformatNumber(inputs.monthlyRent.value);
 
-        if (monthlyPayment && monthlyRentValue && monthlyPayment > monthlyRentValue) {
-            const difference = monthlyPayment - monthlyRentValue;
+        if (monthlyPaymentClp && monthlyRentValue && monthlyPaymentClp > monthlyRentValue) {
+            const difference = Math.round(monthlyPaymentClp - monthlyRentValue);
             inputs.monthlyInvestment.value = currencyFormatter.format(difference);
         } else {
             inputs.monthlyInvestment.value = '';
@@ -65,7 +140,7 @@
     }
 
     function updateDownPaymentFromHomePrice() {
-        const homePriceValue = unformatNumber(inputs.homePrice.value);
+        const homePriceValue = getHomePriceClp();
 
         if (!homePriceValue) {
             inputs.downPayment.value = '';
@@ -79,10 +154,12 @@
     }
 
     function calculateMortgage() {
-        const homePriceValue = unformatNumber(inputs.homePrice.value);
+        const homePriceValue = getHomePriceClp();
         const downPaymentValue = unformatNumber(inputs.downPayment.value);
         const interestRateValue = parseFloat(inputs.interestRate.value);
         const loanTermYears = parseInt(inputs.loanTerm.value, 10);
+
+        lastMonthlyPaymentReferenceClp = 0;
 
         if (!homePriceValue || !downPaymentValue || !loanTermYears || Number.isNaN(interestRateValue)) {
             return null;
@@ -96,29 +173,107 @@
         const monthlyRate = interestRateValue / 100 / 12;
         const numberOfPayments = loanTermYears * 12;
 
-        let monthlyPayment;
-        if (monthlyRate === 0) {
-            monthlyPayment = Math.round(loanAmount / numberOfPayments);
-        } else {
-            const factor = Math.pow(1 + monthlyRate, numberOfPayments);
-            monthlyPayment = Math.round(loanAmount * (monthlyRate * factor) / (factor - 1));
+        const usingUf = isUfSelected();
+        outputs.downPaymentResult.textContent = currencyFormatter.format(downPaymentValue);
+
+        if (!usingUf) {
+            let monthlyPayment;
+            if (monthlyRate === 0) {
+                monthlyPayment = Math.round(loanAmount / numberOfPayments);
+            } else {
+                const factor = Math.pow(1 + monthlyRate, numberOfPayments);
+                monthlyPayment = Math.round(loanAmount * (monthlyRate * factor) / (factor - 1));
+            }
+
+            const totalPayments = monthlyPayment * numberOfPayments;
+            const totalCost = totalPayments + downPaymentValue;
+
+            outputs.monthlyPayment.textContent = currencyFormatter.format(monthlyPayment);
+            outputs.totalCostBuy.textContent = currencyFormatter.format(totalCost);
+            controls.monthlyPaymentPrefix.textContent = '$';
+            controls.monthlyPaymentExplanation.textContent = '';
+            controls.monthlyPaymentRentHint.textContent = '';
+            controls.totalCostLabel.textContent = 'Costo Total';
+            controls.totalCostHelper.textContent = '';
+
+            updateMonthlyInvestment(monthlyPayment);
+            lastMonthlyPaymentReferenceClp = monthlyPayment;
+
+            return {
+                currency: 'CLP',
+                monthlyPayment,
+                totalCost,
+                downPayment: downPaymentValue,
+                loanTerm: loanTermYears,
+                homePrice: homePriceValue,
+                numberOfPayments,
+                totalDividendsClp: totalPayments,
+                referenceMonthlyPaymentClp: monthlyPayment
+            };
         }
 
-        const totalPayments = monthlyPayment * numberOfPayments;
-        const totalCost = totalPayments + downPaymentValue;
+        const ufValue = parseFloat(inputs.ufValue && inputs.ufValue.value);
+        if (!ufValue || Number.isNaN(ufValue) || ufValue <= 0) {
+            return null;
+        }
 
-        outputs.monthlyPayment.textContent = currencyFormatter.format(monthlyPayment);
-        outputs.downPaymentResult.textContent = currencyFormatter.format(downPaymentValue);
+        const homePriceUf = homePriceValue / ufValue;
+        const downPaymentUf = downPaymentValue / ufValue;
+        const loanAmountUf = homePriceUf - downPaymentUf;
+
+        if (loanAmountUf <= 0) {
+            return null;
+        }
+
+        let monthlyPaymentUf;
+        if (monthlyRate === 0) {
+            monthlyPaymentUf = loanAmountUf / numberOfPayments;
+        } else {
+            const factorUf = Math.pow(1 + monthlyRate, numberOfPayments);
+            monthlyPaymentUf = loanAmountUf * (monthlyRate * factorUf) / (factorUf - 1);
+        }
+
+        const monthlyUfGrowthFactor = Math.pow(1 + UF_ANNUAL_GROWTH_RATE, 1 / 12);
+        let totalDividendsClp = 0;
+        let currentUfValue = ufValue;
+
+        for (let month = 0; month < numberOfPayments; month += 1) {
+            totalDividendsClp += monthlyPaymentUf * currentUfValue;
+            currentUfValue *= monthlyUfGrowthFactor;
+        }
+
+        const totalCost = Math.round(totalDividendsClp + downPaymentValue);
+        const firstMonthPaymentClp = monthlyPaymentUf * ufValue;
+
+        outputs.monthlyPayment.textContent = ufFormatter.format(monthlyPaymentUf);
         outputs.totalCostBuy.textContent = currencyFormatter.format(totalCost);
+        controls.monthlyPaymentPrefix.textContent = 'UF';
+        controls.monthlyPaymentExplanation.textContent = `≈ $${currencyFormatter.format(Math.round(firstMonthPaymentClp))} en la cuota 1.`;
 
-        updateMonthlyInvestment(monthlyPayment);
+        const monthlyRentValue = unformatNumber(inputs.monthlyRent.value);
+        if (monthlyRentValue) {
+            controls.monthlyPaymentRentHint.textContent = `Arriendo promedio ingresado: $${currencyFormatter.format(monthlyRentValue)}.`;
+        } else {
+            controls.monthlyPaymentRentHint.textContent = '';
+        }
+
+        controls.totalCostLabel.textContent = `Costo Total (pie + sumatoria de ${numberOfPayments} cuotas)`;
+        controls.totalCostHelper.textContent = 'Incluye reajuste UF proyectado al 3,5% anual.';
+
+        updateMonthlyInvestment(firstMonthPaymentClp);
+        lastMonthlyPaymentReferenceClp = firstMonthPaymentClp;
 
         return {
-            monthlyPayment,
+            currency: 'UF',
+            monthlyPayment: monthlyPaymentUf,
             totalCost,
             downPayment: downPaymentValue,
             loanTerm: loanTermYears,
-            homePrice: homePriceValue
+            homePrice: homePriceValue,
+            numberOfPayments,
+            ufValue,
+            totalDividendsClp: Math.round(totalDividendsClp),
+            referenceMonthlyPaymentClp: firstMonthPaymentClp
         };
     }
 
@@ -190,8 +345,23 @@
         outputs.rentPatrimony.textContent = `$${currencyFormatter.format(rentPatrimony)}`;
         outputs.difference.textContent = `$${currencyFormatter.format(Math.abs(differenceValue))}`;
 
-        const downPaymentValue = unformatNumber(inputs.downPayment.value);
-        scenarioDescriptions.buy.textContent = `Al comprar una vivienda por $${currencyFormatter.format(buyResults.homePrice)}, aportando con un pie de $${currencyFormatter.format(downPaymentValue)} y pagando un dividendo mensual de $${currencyFormatter.format(buyResults.monthlyPayment)}, habrás pagado al final $${currencyFormatter.format(buyResults.totalCost)} (costo total). Al término de ${buyResults.loanTerm} años, con una apreciación de 4% anual, esa propiedad podría ser vendida por al menos $${currencyFormatter.format(finalPropertyValue)}.`;
+        const downPaymentValue = buyResults.downPayment;
+        const monthlyPaymentClpEquivalent = Math.round(buyResults.referenceMonthlyPaymentClp || 0);
+        const totalDividendPayments = Math.max(0, Math.round(buyResults.totalCost - buyResults.downPayment));
+        const dividendDescription = buyResults.currency === 'UF'
+            ? `UF ${ufFormatter.format(buyResults.monthlyPayment)} (≈ $${currencyFormatter.format(monthlyPaymentClpEquivalent)} en la cuota 1)`
+            : `$${currencyFormatter.format(Math.round(buyResults.monthlyPayment))}`;
+        const homePriceDescription = currencyFormatter.format(buyResults.homePrice);
+        const downPaymentDescription = currencyFormatter.format(downPaymentValue);
+        const totalDividendsDescription = currencyFormatter.format(totalDividendPayments);
+        const totalCostDescription = currencyFormatter.format(buyResults.totalCost);
+        const finalPropertyValueDescription = currencyFormatter.format(finalPropertyValue);
+
+        if (buyResults.currency === 'UF') {
+            scenarioDescriptions.buy.textContent = `Al comprar una vivienda por $${homePriceDescription}, aportando con un pie de $${downPaymentDescription} y pagando un dividendo mensual de ${dividendDescription}, terminarías desembolsando aproximadamente $${totalDividendsDescription} en dividendos (considerando un reajuste UF de 3,5% anual). Sumado al pie, el costo total proyectado sería de $${totalCostDescription}. Al término de ${buyResults.loanTerm} años, con una apreciación de 4% anual, esa propiedad podría valer alrededor de $${finalPropertyValueDescription}.`;
+        } else {
+            scenarioDescriptions.buy.textContent = `Al comprar una vivienda por $${homePriceDescription}, aportando con un pie de $${downPaymentDescription} y pagando un dividendo mensual de ${dividendDescription}, habrás pagado al final $${totalCostDescription} (pie + dividendos). Al término de ${buyResults.loanTerm} años, con una apreciación de 4% anual, esa propiedad podría ser vendida por al menos $${finalPropertyValueDescription}.`;
+        }
 
         const initialInvestmentAmount = unformatNumber(inputs.initialInvestment.value);
         scenarioDescriptions.rent.textContent = `Al arrendar una vivienda e invertir la diferencia, con un monto inicial de $${currencyFormatter.format(initialInvestmentAmount)} (igual al pie de la casa), luego de ${buyResults.loanTerm} años con una rentabilidad de ${inputs.annualReturn.value}% anual, podrías acumular $${currencyFormatter.format(rentResults.finalInvestmentValue)}.`;
@@ -214,15 +384,23 @@
     function handleMonthlyRentInput() {
         formatCurrencyInput(inputs.monthlyRent);
 
-        const currentMonthlyPayment = unformatNumber(outputs.monthlyPayment.textContent);
-        if (currentMonthlyPayment) {
-            updateMonthlyInvestment(currentMonthlyPayment);
+        if (isUfSelected()) {
+            const monthlyRentValue = unformatNumber(inputs.monthlyRent.value);
+            controls.monthlyPaymentRentHint.textContent = monthlyRentValue
+                ? `Arriendo promedio ingresado: $${currencyFormatter.format(monthlyRentValue)}.`
+                : '';
+        } else {
+            controls.monthlyPaymentRentHint.textContent = '';
+        }
+
+        if (lastMonthlyPaymentReferenceClp) {
+            updateMonthlyInvestment(lastMonthlyPaymentReferenceClp);
         }
     }
 
     function attachEventListeners() {
         inputs.homePrice.addEventListener('input', () => {
-            formatCurrencyInput(inputs.homePrice);
+            formatHomePriceInput();
             updateDownPaymentFromHomePrice();
         });
         inputs.downPayment.addEventListener('input', () => {
@@ -230,6 +408,54 @@
             updateInitialInvestment();
         });
         inputs.monthlyRent.addEventListener('input', handleMonthlyRentInput);
+
+        if (controls.dividendCurrencyToggle) {
+            controls.dividendCurrencyToggle.addEventListener('change', () => {
+                const usingUf = isUfSelected();
+                const ufValueNumber = parseFloat(inputs.ufValue && inputs.ufValue.value);
+                if (usingUf) {
+                    const clpValue = unformatNumber(inputs.homePrice.value);
+                    if (clpValue && ufValueNumber && !Number.isNaN(ufValueNumber) && ufValueNumber > 0) {
+                        inputs.homePrice.value = ufFormatter.format(clpValue / ufValueNumber);
+                    } else {
+                        inputs.homePrice.value = '';
+                    }
+                } else {
+                    const homePriceUf = parseUfInput(inputs.homePrice.value);
+                    if (homePriceUf && ufValueNumber && !Number.isNaN(ufValueNumber) && ufValueNumber > 0) {
+                        inputs.homePrice.value = currencyFormatter.format(Math.round(homePriceUf * ufValueNumber));
+                    } else {
+                        inputs.homePrice.value = '';
+                    }
+                }
+
+                updateHomePriceLabel(usingUf);
+                formatHomePriceInput();
+                updateDownPaymentFromHomePrice();
+                if (controls.ufInputGroup) {
+                    controls.ufInputGroup.classList.toggle('hidden', !usingUf);
+                }
+                controls.monthlyPaymentPrefix.textContent = usingUf ? 'UF' : '$';
+                if (!usingUf) {
+                    controls.monthlyPaymentExplanation.textContent = '';
+                    controls.monthlyPaymentRentHint.textContent = '';
+                    controls.totalCostLabel.textContent = 'Costo Total';
+                    controls.totalCostHelper.textContent = '';
+                } else {
+                    handleMonthlyRentInput();
+                }
+                calculateAll();
+            });
+        }
+
+        if (inputs.ufValue) {
+            inputs.ufValue.addEventListener('input', () => {
+                if (isUfSelected()) {
+                    updateDownPaymentFromHomePrice();
+                }
+                calculateAll();
+            });
+        }
 
         document.querySelectorAll('.calculate-btn').forEach((button) => {
             button.addEventListener('click', calculateAll);
@@ -240,5 +466,11 @@
         attachEventListeners();
         updateDownPaymentFromHomePrice();
         updateInitialInvestment();
+        if (controls.ufInputGroup) {
+            controls.ufInputGroup.classList.toggle('hidden', !isUfSelected());
+        }
+        controls.monthlyPaymentPrefix.textContent = isUfSelected() ? 'UF' : '$';
+        updateHomePriceLabel(isUfSelected());
+        formatHomePriceInput();
     });
 })();

--- a/compraroarrendar.html
+++ b/compraroarrendar.html
@@ -21,9 +21,19 @@
                 <p>Crédito hipotecario</p>
             </div>
             <div class="panel-content">
-                <div class="input-group">
-                    <label for="homePrice">Valor de la Propiedad (CLP)</label>
-                    <input type="text" id="homePrice" class="currency-input" placeholder="Ej: 100.000.000">
+                <div class="input-group home-price-group">
+                    <div class="home-price-field">
+                        <label for="homePrice" id="homePriceLabel" data-home-price-label>Valor de la Propiedad (CLP)</label>
+                        <input type="text" id="homePrice" class="currency-input" placeholder="Ej: 100.000.000" data-home-price-input>
+                    </div>
+                    <div class="currency-toggle-column currency-toggle" role="group" aria-label="Selecciona la moneda del valor de la propiedad">
+                        <span class="currency-toggle-label">CLP</span>
+                        <label class="switch">
+                            <input type="checkbox" id="dividendCurrencyToggle" aria-label="Alternar valor de la propiedad entre CLP y UF">
+                            <span class="slider"></span>
+                        </label>
+                        <span class="currency-toggle-label">UF</span>
+                    </div>
                 </div>
                 
                 <div class="input-group">
@@ -40,12 +50,20 @@
                     <label for="loanTerm">Plazo del Crédito (años)</label>
                     <input type="number" id="loanTerm" placeholder="Ej: 25" value="25">
                 </div>
-                
+
+                <div class="input-group hidden" data-uf-input-group>
+                    <label for="ufValue">Valor UF actual (CLP)</label>
+                    <input type="number" id="ufValue" min="1" step="0.01" value="36000">
+                    <p class="helper-text">Se proyecta un crecimiento anual de 3,5&nbsp;%.</p>
+                </div>
+
                 <button type="button" class="calculate-btn">Calcular Compra</button>
 
                 <div class="monthly-payment-container">
                     <h3>Dividendo mensual estimado</h3>
-                    <div class="amount">$<span id="monthlyPayment">0</span></div>
+                    <div class="amount"><span id="monthlyPaymentPrefix">$</span><span id="monthlyPayment">0</span></div>
+                    <p class="helper-text" id="monthlyPaymentExplanation"></p>
+                    <p class="helper-text" id="monthlyPaymentRentHint"></p>
                 </div>
 
                 <div class="results-summary">
@@ -54,8 +72,9 @@
                         <div class="value">$<span id="downPaymentResult">0</span></div>
                     </div>
                     <div class="result-card">
-                        <h3>Costo Total</h3>
+                        <h3 id="totalCostLabel">Costo Total</h3>
                         <div class="value">$<span id="totalCostBuy">0</span></div>
+                        <p class="helper-text" id="totalCostHelper"></p>
                     </div>
                 </div>
             </div>

--- a/docs/sketch-valor-propiedad-toggle.md
+++ b/docs/sketch-valor-propiedad-toggle.md
@@ -1,0 +1,25 @@
+# Sketch: Toggle CLP/UF junto al campo "Valor de la Propiedad"
+
+## Objetivos clave
+- Ubicar el selector de moneda como una mini columna adosada al campo de precio para mantener la altura de los paneles.
+- Permitir que la persona ingrese el valor de la propiedad en CLP o UF y convertir internamente a CLP para todos los cálculos y resultados.
+- Mantener el resto de los campos (pie, arriendo, totales) formateados en pesos chilenos y clarificar la sumatoria de cuotas cuando se proyecta en UF.
+
+## Vista previa en texto
+```
+┌─────────────────────────────┐  ┌────────────┐
+│ Valor de la Propiedad (CLP) │  │  CLP  ○ UF │
+│ [ 100.000.000            ]  │  └────────────┘
+└─────────────────────────────┘
+│ Pie inicial 20% (CLP)       │
+│ [ 20.000.000              ] │
+└─────────────────────────────┘
+```
+- En modo **CLP**, el campo conserva el formateo de miles y el cálculo del pie automático en pesos.
+- Al cambiar a **UF**, el campo muestra el valor en UF (permite decimales), el pie se recalcula en CLP usando el valor UF ingresado y se despliega el panel para capturar dicho valor.
+- Los botones de "Calcular" de ambos paneles mantienen su alineación porque el nuevo selector ocupa el mismo alto que el input en desktop y se apila debajo en mobile.
+
+## Detalles de interacción
+1. Cambiar de CLP a UF convierte el número actual utilizando el valor UF disponible (cuando existe) y actualiza la etiqueta del campo.
+2. El valor del pie y las inversiones sincronizadas se recalculan automáticamente con el equivalente en CLP.
+3. El "Dividendo mensual" muestra UF con una referencia en CLP para la primera cuota, mientras que el "Costo Total" aclara la sumatoria de cuotas en CLP, manteniendo consistencia de moneda en los resultados.


### PR DESCRIPTION
## Summary
- move the CLP/UF selector into a side column next to the property value field to keep the panels aligned
- adjust mortgage calculations to convert property prices between CLP and UF while keeping downstream totals in CLP
- document the updated layout with an ASCII sketch for reference

## Testing
- not run (static site changes)

------
https://chatgpt.com/codex/tasks/task_b_68efaff7d97883278fae986724a11e29